### PR TITLE
Remove SUBDIR in favor of newer M parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ KDIR:=/lib/modules/$(shell uname -r)/build
 endif
 PWD:=$(shell pwd)
 default:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules


### PR DESCRIPTION
Starting kernel5.3 SUBDIR parameter was removed in favor of M parameter.